### PR TITLE
Allow the user to sort discover view results by favorite count

### DIFF
--- a/Places/Base.lproj/Main.storyboard
+++ b/Places/Base.lproj/Main.storyboard
@@ -325,6 +325,8 @@
                     </view>
                     <navigationItem key="navigationItem" title="Discover" id="80M-Zo-ZwF"/>
                     <connections>
+                        <outlet property="decreasingFavoritesButton" destination="SbI-Ej-FGg" id="1EP-kF-sc3"/>
+                        <outlet property="increasingFavoritesButton" destination="A0r-57-fjA" id="EU7-64-9f8"/>
                         <outlet property="searchBar" destination="Ohj-g5-9Me" id="gOb-lQ-ECc"/>
                         <outlet property="searchResults" destination="onh-dv-iNd" id="dOo-j6-qLI"/>
                     </connections>

--- a/Places/Base.lproj/Main.storyboard
+++ b/Places/Base.lproj/Main.storyboard
@@ -190,7 +190,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="onh-dv-iNd">
-                                <rect key="frame" x="0.0" y="107" width="414" height="706"/>
+                                <rect key="frame" x="0.0" y="152" width="414" height="661"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="PlaceCell" rowHeight="184" id="02U-Pg-wkZ" customClass="PlaceTableViewCell">
@@ -276,12 +276,40 @@
                                 <rect key="frame" x="0.0" y="56" width="414" height="51"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f3J-cV-ZD5">
+                                <rect key="frame" x="0.0" y="107" width="414" height="45"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A0r-57-fjA">
+                                        <rect key="frame" x="10" y="5" width="102.5" height="35"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="gray" image="arrow.up" catalog="system" title="Favorited"/>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SbI-Ej-FGg">
+                                        <rect key="frame" x="120.5" y="5" width="102.5" height="35"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="gray" image="arrow.down" catalog="system" title="Favorited"/>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="SbI-Ej-FGg" firstAttribute="leading" secondItem="A0r-57-fjA" secondAttribute="trailing" constant="8" symbolic="YES" id="1Sh-G8-JJa"/>
+                                    <constraint firstItem="A0r-57-fjA" firstAttribute="leading" secondItem="f3J-cV-ZD5" secondAttribute="leading" constant="10" id="A0s-hP-NgA"/>
+                                    <constraint firstAttribute="bottom" secondItem="A0r-57-fjA" secondAttribute="bottom" constant="5" id="JHv-4e-Fqz"/>
+                                    <constraint firstItem="A0r-57-fjA" firstAttribute="top" secondItem="f3J-cV-ZD5" secondAttribute="top" constant="5" id="Kgp-oT-zOC"/>
+                                    <constraint firstItem="SbI-Ej-FGg" firstAttribute="top" secondItem="A0r-57-fjA" secondAttribute="top" id="N7q-F0-ybK"/>
+                                    <constraint firstAttribute="height" constant="45" id="T9X-IX-bWC"/>
+                                    <constraint firstAttribute="bottom" secondItem="SbI-Ej-FGg" secondAttribute="bottom" constant="5" id="efH-OF-HD9"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Z8x-UA-SPz"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="onh-dv-iNd" firstAttribute="top" secondItem="f3J-cV-ZD5" secondAttribute="bottom" id="Aw9-NQ-RWe"/>
+                            <constraint firstItem="f3J-cV-ZD5" firstAttribute="top" secondItem="Ohj-g5-9Me" secondAttribute="bottom" id="H1M-sT-aMD"/>
                             <constraint firstItem="onh-dv-iNd" firstAttribute="bottom" secondItem="Z8x-UA-SPz" secondAttribute="bottom" id="NnG-so-1I0"/>
-                            <constraint firstItem="onh-dv-iNd" firstAttribute="top" secondItem="Ohj-g5-9Me" secondAttribute="bottom" id="aNd-E5-pjl"/>
+                            <constraint firstItem="f3J-cV-ZD5" firstAttribute="leading" secondItem="Ohj-g5-9Me" secondAttribute="leading" id="ZRd-bi-2VD"/>
+                            <constraint firstItem="f3J-cV-ZD5" firstAttribute="trailing" secondItem="Ohj-g5-9Me" secondAttribute="trailing" id="aFz-jR-QrN"/>
                             <constraint firstItem="onh-dv-iNd" firstAttribute="leading" secondItem="Z8x-UA-SPz" secondAttribute="leading" id="doV-vO-fyc"/>
                             <constraint firstItem="Ohj-g5-9Me" firstAttribute="leading" secondItem="Z8x-UA-SPz" secondAttribute="leading" id="ghr-9z-31A"/>
                             <constraint firstItem="Z8x-UA-SPz" firstAttribute="trailing" secondItem="Ohj-g5-9Me" secondAttribute="trailing" id="ksL-dB-yNO"/>
@@ -521,6 +549,8 @@
         <segue reference="jge-a7-93w"/>
     </inferredMetricsTieBreakers>
     <resources>
+        <image name="arrow.down" catalog="system" width="120" height="128"/>
+        <image name="arrow.up" catalog="system" width="120" height="128"/>
         <image name="heart" catalog="system" width="128" height="109"/>
         <image name="list.bullet.rectangle.portrait" catalog="system" width="115" height="128"/>
         <image name="network" catalog="system" width="128" height="121"/>

--- a/Places/Base.lproj/Main.storyboard
+++ b/Places/Base.lproj/Main.storyboard
@@ -283,11 +283,17 @@
                                         <rect key="frame" x="10" y="5" width="102.5" height="35"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="gray" image="arrow.up" catalog="system" title="Favorited"/>
+                                        <connections>
+                                            <action selector="didTapSortByIncreasingFavorites:" destination="HV6-B5-JQC" eventType="touchUpInside" id="yKf-6c-vYK"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SbI-Ej-FGg">
                                         <rect key="frame" x="120.5" y="5" width="102.5" height="35"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="gray" image="arrow.down" catalog="system" title="Favorited"/>
+                                        <connections>
+                                            <action selector="didTapSortByDecreasingFavorites:" destination="HV6-B5-JQC" eventType="touchUpInside" id="gba-Cw-Xei"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/Places/View Controllers/DiscoverViewController.m
+++ b/Places/View Controllers/DiscoverViewController.m
@@ -15,7 +15,11 @@
 @import Parse;
 
 @interface DiscoverViewController () <UISearchBarDelegate, UITableViewDelegate, UITableViewDataSource>
-@property (nonatomic, strong) NSArray *places;
+@property (nonatomic, strong) NSArray *placesToDisplay;
+@property (nonatomic) BOOL *sortByIncreasingFavorites;
+@property (nonatomic) BOOL *sortByDecreasingFavorites;
+- (IBAction)didTapSortByIncreasingFavorites:(id)sender;
+- (IBAction)didTapSortByDecreasingFavorites:(id)sender;
 
 @end
 
@@ -31,6 +35,55 @@
     self.searchResults.rowHeight = UITableViewAutomaticDimension;
     
     [self loadDefaultPlacesToDisplay];
+}
+
+
+// sort self.places to be an array that starts from most favorited to least favorited
+- (void)sortResultsByIncreasingFavorites {
+//    NSMutableArray *searchResultPlaceIDs = [[NSMutableArray alloc] init];
+//    for (NSDictionary *googlePlace in self.places) {
+//        [searchResultPlaceIDs addObject:googlePlace[@"place_id"]];
+//    }
+//    NSLog(@"Got searchResultPlaceIDs %@", searchResultPlaceIDs);
+//
+//    PFQuery *query = [PFQuery queryWithClassName:@"Place"];
+//    [query whereKey:@"place_id" containsAllObjectsInArray:searchResultPlaceIDs];
+//    [query orderByDescending:@"favoriteCount"];
+//    [query findObjectsInBackgroundWithBlock:^(NSArray *sortedPlaceParseObjects, NSError *error) {
+//      if (!error) {
+//        NSLog(<#NSString * _Nonnull format, ...#>)
+//      } else {
+//        // Log details of the failure
+//        NSLog(@"Error: %@ %@", error, [error userInfo]);
+//      }
+//    }];
+    
+//    NSMutableDictionary *placesToFavoriteCount = [[NSMutableDictionary alloc] init];
+//
+//    // set placesToFavoriteCount
+//    for (NSDictionary *googlePlace in self.places) {
+//        PFQuery *query = [PFQuery queryWithClassName:@"Place"];
+//        [query whereKey:@"placeID" equalTo:googlePlace[@"place_id"]];
+//        [query findObjectsInBackgroundWithBlock:^(NSArray *parsePlaceObjects, NSError *error) {
+//            if (error) {
+//                NSLog(@"Got an error while fetching place from Parse");
+//            } else {
+//                if ([parsePlaceObjects count] == 1) {
+//                    Place *parsePlaceObject = parsePlaceObjects[0];
+//                    NSLog(@"Got a Parse Place Object for %@ with favorite count %@", parsePlaceObject[@"name"], parsePlaceObject[@"favoriteCount"]);
+//                    [placesToFavoriteCount setObject:parsePlaceObject[@"favoriteCount"] forKey:googlePlace[@"place_id"]];
+//                    NSLog(@"Should have added key value pair to placesToFavoriteCount %@", placesToFavoriteCount);
+//                }
+//            }
+//        }];
+//    }
+//
+//    NSLog(@"The placesToFavoriteCount dictionary has been set and is %@", placesToFavoriteCount);
+//
+//    // set self.places to be sorted from most to least favorited
+//    self.places = [placesToFavoriteCount keysSortedByValueUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+//        return [obj1 compare:obj2];
+//    }];
 }
 
 - (void)fetchPlaces:(NSString *)query {
@@ -50,17 +103,39 @@
            }
            else {
                NSDictionary *dataDictionary = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
-               self.places = dataDictionary[@"results"];
-               NSLog(@"%@", self.places);
-               [self.searchResults reloadData];
+               NSArray *resultsAsGooglePlaceObjects = dataDictionary[@"results"];
+               for (NSDictionary *googlePlaceObject in resultsAsGooglePlaceObjects) {
+                  [self createNewPlaceModelInParseIfNecessary:googlePlaceObject];
+               }
+               
+               // set self.placesToDisplay as Parse object version of resultsAsGooglePlaceObjects
+               NSMutableArray *searchResultPlaceIDs = [[NSMutableArray alloc] init];
+               for (NSDictionary *googlePlace in resultsAsGooglePlaceObjects) {
+                   [searchResultPlaceIDs addObject:googlePlace[@"place_id"]];
+               }
+               NSLog(@"Got searchResultPlaceIDs %@", searchResultPlaceIDs);
+
+               PFQuery *query = [PFQuery queryWithClassName:@"Place"];
+               [query whereKey:@"placeID" containedIn:searchResultPlaceIDs];
+//               [query orderByDescending:@"favoriteCount"];
+               [query findObjectsInBackgroundWithBlock:^(NSArray *parsePlaceObjects, NSError *error) {
+                 if (!error) {
+                     self.placesToDisplay = parsePlaceObjects;
+                     NSLog(@"self.placesToDisplay is now has %lu elements", (unsigned long)[self.placesToDisplay count]);
+                     [self.searchResults reloadData];
+                 } else {
+                   // Log details of the failure
+                   NSLog(@"Error: %@ %@", error, [error userInfo]);
+                 }
+               }];
            }
        }];
     [task resume];
-    
 }
 
 - (void) loadDefaultPlacesToDisplay {
     [self fetchPlaces:@"to do"];
+    NSLog(@"self.placesToDisplay in loadDefaultPlacesToDisplay has %lu elements", [self.placesToDisplay count]);
 }
 
 #pragma mark - UISearchBarDelegate
@@ -112,25 +187,11 @@
     return ![currentUser[@"favoritedPlaces"] containsObject:placeID];
 }
 
-- (void)setAttributesOfPlaceCell:(NSDictionary *)place placeTableViewCell:(PlaceTableViewCell *)placeTableViewCell {
+- (void)setAttributesOfPlaceCell:(Place *)place placeTableViewCell:(PlaceTableViewCell *)placeTableViewCell {
     placeTableViewCell.placeName.text = place[@"name"];
     placeTableViewCell.placeRatings.text = [NSString stringWithFormat:@"%@ out of 5 stars", place[@"rating"]];
-    placeTableViewCell.placeAddress.text = place[@"formatted_address"];
-    
-    // get favorite count
-    PFQuery *query = [PFQuery queryWithClassName:@"Place"];
-    [query whereKey:@"placeID" equalTo:place[@"place_id"]];
-    [query findObjectsInBackgroundWithBlock:^(NSArray *places, NSError *error) {
-        if (error) {
-            NSLog(@"Got an error while fetching places");
-        } else {
-            if ([places count] == 1) {
-                NSDictionary *parsePlaceObject = places[0];
-                placeTableViewCell.placeFavoriteCount.text = [NSString stringWithFormat:@"Favorited by %@ other users", parsePlaceObject[@"favoriteCount"]];
-            }
-        }
-    }];
-    
+    placeTableViewCell.placeAddress.text = place[@"address"];
+    placeTableViewCell.placeFavoriteCount.text = [NSString stringWithFormat:@"Favorited by %@ other users", place[@"favoriteCount"]];
     
     // get first photo to display
     NSString *firstPhotoReference = ((place[@"photos"])[0])[@"photo_reference"];
@@ -141,7 +202,7 @@
     // Configure addToFavorites button
     PFUser *currentUser = [PFUser currentUser];
     
-    if ([self notFavoritedBy:currentUser forPlaceID:place[@"place_id"]]) {
+    if ([self notFavoritedBy:currentUser forPlaceID:place[@"placeID"]]) {
         [placeTableViewCell.addToFavoritesButton setTitle:@" Add to Favorites" forState:UIControlStateNormal];
         [placeTableViewCell.addToFavoritesButton setImage:[UIImage systemImageNamed:@"heart.fill"] forState:UIControlStateNormal];
     } else {
@@ -152,18 +213,29 @@
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath {
     PlaceTableViewCell *placeTableViewCell = [tableView dequeueReusableCellWithIdentifier:@"PlaceCell" forIndexPath:indexPath];
-    NSDictionary *place = self.places[indexPath.row];
-
-    [self createNewPlaceModelInParseIfNecessary:place];
-    [self setAttributesOfPlaceCell:place placeTableViewCell:placeTableViewCell];
-    placeTableViewCell.place = place;
+    Place *parsePlace = self.placesToDisplay[indexPath.row];
+    
+    [self setAttributesOfPlaceCell:parsePlace placeTableViewCell:placeTableViewCell];
+    placeTableViewCell.place = parsePlace;
     
     return placeTableViewCell;
 }
 
 - (NSInteger)tableView:(nonnull UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.places.count;
+    return self.placesToDisplay.count;
 }
 
 
+- (IBAction)didTapSortByDecreasingFavorites:(id)sender {
+
+}
+
+- (IBAction)didTapSortByIncreasingFavorites:(id)sender {
+    // if sortByIncreasingFavorites:
+        // change button style to filled
+        // reload current results to be sorted by increasing order
+        // ensure future results will be sorted by increasing order
+    // else
+        // change button style to gray
+}
 @end

--- a/Places/Views/PlaceTableViewCell.h
+++ b/Places/Views/PlaceTableViewCell.h
@@ -6,6 +6,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "Place.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (IBAction)didTapAddToFavorites:(id)sender;
 @property (weak, nonatomic) IBOutlet UIButton *addToFavoritesButton;
 
-@property (weak, nonatomic) NSDictionary *place;
+@property (weak, nonatomic) Place *place;
 
 
 @end

--- a/Places/Views/PlaceTableViewCell.m
+++ b/Places/Views/PlaceTableViewCell.m
@@ -24,44 +24,32 @@
 }
 
 - (bool)notFavoritedBy:(PFUser *)currentUser {
-    return ![currentUser[@"favoritedPlaces"] containsObject:self.place[@"place_id"]];
+    return ![currentUser[@"favoritedPlaces"] containsObject:self.place[@"placeID"]];
 }
 
 - (IBAction)didTapAddToFavorites:(id)sender {
     PFUser *currentUser = [PFUser currentUser];
-
-    PFQuery *query = [PFQuery queryWithClassName:@"Place"];
-    [query whereKey:@"placeID" equalTo:self.place[@"place_id"]];
-    [query findObjectsInBackgroundWithBlock:^(NSArray *places, NSError *error) {
-        if (error) {
-            NSLog(@"Got error getting place in didTapAddToFavorites");
-        } else {
-            if ([places count] != 1) {
-                NSLog(@"Could not find place for place_id to increment favoriteCount");
-            } else {
-                Place *parsePlaceObject = places[0];
-                if ([self notFavoritedBy:currentUser]) {
-                    // Add to user's favoritedPlaces array
-                    [currentUser addObject:self.place[@"place_id"] forKey:@"favoritedPlaces"];
-                    [currentUser saveInBackground];
-                    NSLog(@"The user's favoritedPlaces array is now: %@", currentUser[@"favoritedPlaces"]);
-                    
-                    // Increment Place's favorite count
-                    [parsePlaceObject incrementKey:@"favoriteCount"];
-                    [parsePlaceObject saveInBackground];
-                    NSLog(@"Incremented favorite count for %@", parsePlaceObject[@"name"]);
-                    
-                    // Change button UI
-                    [self.addToFavoritesButton setTitle:@" Added to Favorites" forState:UIControlStateNormal];
-                    [self.addToFavoritesButton setImage:[UIImage systemImageNamed:@"checkmark"] forState:UIControlStateNormal];
-                    
-                    // Update favorite count label
-                    self.placeFavoriteCount.text = [NSString stringWithFormat:@"Favorited by %@ other users", parsePlaceObject[@"favoriteCount"]];
-                } else {
-                    NSLog(@"%@ already favorited by user", parsePlaceObject[@"name"]);
-                }
-            }
-        }
-    }];
+    
+    if ([self notFavoritedBy:currentUser]) {
+        // Add to user's favoritedPlaces array
+        [currentUser addObject:self.place[@"placeID"] forKey:@"favoritedPlaces"];
+        [currentUser saveInBackground];
+        NSLog(@"The user's favoritedPlaces array is now: %@", currentUser[@"favoritedPlaces"]);
+        
+        // Increment Place's favorite count
+        [self.place incrementKey:@"favoriteCount"];
+        [self.place saveInBackground];
+        NSLog(@"Incremented favorite count for %@", self.place[@"name"]);
+        
+        // Change button UI
+        [self.addToFavoritesButton setTitle:@" Added to Favorites" forState:UIControlStateNormal];
+        [self.addToFavoritesButton setImage:[UIImage systemImageNamed:@"checkmark"] forState:UIControlStateNormal];
+        
+        // Update favorite count label
+        self.placeFavoriteCount.text = [NSString stringWithFormat:@"Favorited by %@ other users", self.place[@"favoriteCount"]];
+    } else {
+        NSLog(@"%@ already favorited by user", self.place[@"name"]);
+    }
 }
+
 @end

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ An app that helps you plan, track, and share the places you go.
     * There is a tab which shows a table view that displays the user's itineraries. 
     * Users can create new itineraries from this tab. 
 * User can utilize a discover tab to search for places and favorite them. 
-    * There is a filtering functionality for multiple attributes, such as category of location, star rating, price range, dates/availability, etc.
     * User can search for any granularity of location (from cities to continents).
-    * TODO: Research Google Maps API to see what capabilities it provides us with. How is search and filtering done? What can we filter by? Seek to implement a more custom search/filtering algorithm than the API to make this a *planned technical challenge*.
+    * User can sort the results on the discover tab by how many other app users have favorited or added the place to itinerary - *planned technical challenge*.
+        * If sort setting is set:
+            * current results will sort
+            * future results will sort
+        * Unclicking the sort preference will undo the sort setting such that 
+            * current results will unsort
+            * future results will not be sorted by previous preference
+        * User should not be able to select both increasing and decreasing at the same time. Selecting one will undo the other, kind of like a toggle. User can also deselect both and revert to default sorting. 
 * User can share an itinerary - *planned technical challenge*.
     * Upon hitting share, an action sheet pops up and a link will be generated.
     * The itinerary will be stored in the Parse database.
@@ -247,3 +253,8 @@ Discover Page V1
 Favoriting V1
 
 <img src="https://github.com/iristfu/Places/blob/main/favorites_v1.gif" width=400>
+
+Discover Page V2 - with sorting by favorite count
+
+<img src="https://github.com/iristfu/Places/blob/main/discover_v2_with_sorting.gif" width=400>
+


### PR DESCRIPTION
Closes #14.

For this feature:
- Add UI that allows the user to sort by increasing or decreasing favorite count
- If sort setting is set:
   - current results will sort according to new setting
   - future results will sort according to new setting
- Unclicking the sort preference will undo the sort setting such that
  - current results will unsort
  - future results will not be sorted by previous setting
 - User should not be able to select both increasing and decreasing at the same time. Selecting one will undo the other, kind of like a toggle. User can also deselect both and revert to default sorting. 

Along the way, I realized that I needed to change my self.placesToDisplay array in the discover view controller to be an array of Parse Place objects rather than an array of dictionaries conforming to the Google Place object. I rewrote some of my code to accommodate for this; however, I think my refactored code may be causing a bug now due to methods running asynchronously (which also makes the bug hard to replicate).