### PR TITLE
Implement link sharing for itineraries

### DIFF
--- a/Places/AppDelegate.m
+++ b/Places/AppDelegate.m
@@ -32,6 +32,30 @@
     
 }
 
+- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
+    NSLog(@"url recieved: %@", url);
+    NSLog(@"query string: %@", [url query]);
+    NSLog(@"host: %@", [url host]);
+    NSLog(@"url path: %@", [url path]);
+    NSDictionary *dict = [self parseQueryString:[url query]];
+    NSLog(@"query dict: %@", dict);
+    return YES;
+}
+
+- (NSDictionary *)parseQueryString:(NSString *)query {
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+    NSArray *pairs = [query componentsSeparatedByString:@"&"];
+    
+    for (NSString *pair in pairs) {
+        NSArray *elements = [pair componentsSeparatedByString:@"="];
+        NSString *key = [[elements objectAtIndex:0] stringByRemovingPercentEncoding];
+        NSString *val = [[elements objectAtIndex:1] stringByRemovingPercentEncoding];
+        
+        [dict setObject:val forKey:key];
+    }
+    return dict;
+}
+
 
 #pragma mark - UISceneSession lifecycle
 

--- a/Places/AppDelegate.m
+++ b/Places/AppDelegate.m
@@ -59,21 +59,6 @@
     return YES;
 }
 
-- (NSDictionary *)parseQueryString:(NSString *)query {
-    NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-    NSArray *pairs = [query componentsSeparatedByString:@"&"];
-    
-    for (NSString *pair in pairs) {
-        NSArray *elements = [pair componentsSeparatedByString:@"="];
-        NSString *key = [[elements objectAtIndex:0] stringByRemovingPercentEncoding];
-        NSString *val = [[elements objectAtIndex:1] stringByRemovingPercentEncoding];
-        
-        [dict setObject:val forKey:key];
-    }
-    return dict;
-}
-
-
 #pragma mark - UISceneSession lifecycle
 
 

--- a/Places/AppDelegate.m
+++ b/Places/AppDelegate.m
@@ -32,8 +32,8 @@
     
 }
 
-- (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url {
-    NSLog(@"url recieved: %@", url);
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    NSLog(@"url recieved: %@", url.absoluteString);
     NSLog(@"query string: %@", [url query]);
     NSLog(@"host: %@", [url host]);
     NSLog(@"url path: %@", [url path]);

--- a/Places/AppDelegate.m
+++ b/Places/AppDelegate.m
@@ -7,6 +7,7 @@
 
 #import "AppDelegate.h"
 #import "Parse/Parse.h"
+#import "ItineraryDetailViewController.h"
 @import GooglePlaces;
 
 @interface AppDelegate ()
@@ -34,11 +35,27 @@
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
     NSLog(@"url recieved: %@", url.absoluteString);
-    NSLog(@"query string: %@", [url query]);
     NSLog(@"host: %@", [url host]);
     NSLog(@"url path: %@", [url path]);
-    NSDictionary *dict = [self parseQueryString:[url query]];
-    NSLog(@"query dict: %@", dict);
+    NSString *itineraryObjectID = [[url path] substringFromIndex:1]; // remove "/" from path
+    NSLog(@"itineraryObjectID: %@", itineraryObjectID);
+
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    ItineraryDetailViewController *itineraryDetailViewController =[storyboard instantiateViewControllerWithIdentifier:@"ItineraryDetailView"];
+    NSLog(@"Have an itinerary Detail View Controller %@", itineraryDetailViewController);
+    
+    PFQuery *query = [PFQuery queryWithClassName:@"Itinerary"];
+    [query getObjectInBackgroundWithId:itineraryObjectID block:^(PFObject *itinerary, NSError *error) {
+        if (!error) {
+            itineraryDetailViewController.itinerary = itinerary;
+            NSLog(@"Got the itinerary to set the detail view with itinerary %@", itineraryDetailViewController.itinerary);
+            
+            UITabBarController *tabBarController = self.window.rootViewController;
+            [tabBarController setSelectedIndex:2];
+            [[tabBarController selectedViewController] pushViewController:itineraryDetailViewController animated:true];
+        }
+    }];
+    
     return YES;
 }
 

--- a/Places/Base.lproj/Main.storyboard
+++ b/Places/Base.lproj/Main.storyboard
@@ -467,7 +467,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qEU-HS-c5M" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2704" y="1696"/>
+            <point key="canvasLocation" x="4007" y="1696"/>
         </scene>
         <!--Itineraries-->
         <scene sceneID="lZK-ba-NeA">
@@ -550,7 +550,7 @@
         <!--Itinerary Detail View Controller-->
         <scene sceneID="maD-3z-hfj">
             <objects>
-                <viewController id="BnL-j1-YeD" customClass="ItineraryDetailViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ItineraryDetailView" id="BnL-j1-YeD" customClass="ItineraryDetailViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lch-lL-Egy">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1024,7 +1024,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sNy-2R-9KD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3793" y="1696"/>
+            <point key="canvasLocation" x="4006" y="2515"/>
         </scene>
         <!--Itineraries-->
         <scene sceneID="hZX-df-Zat">

--- a/Places/Info.plist
+++ b/Places/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>places</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>com.irisfu.places</string>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Places/Info.plist
+++ b/Places/Info.plist
@@ -5,12 +5,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.irisfu.places</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>places</string>
 			</array>
-			<key>CFBundleURLName</key>
-			<string>com.irisfu.places</string>
 		</dict>
 	</array>
 	<key>UIApplicationSceneManifest</key>

--- a/Places/SceneDelegate.m
+++ b/Places/SceneDelegate.m
@@ -26,6 +26,9 @@
     
 }
 
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+    NSLog(@"Continuing to handle user activity");
+}
 
 - (void)sceneDidDisconnect:(UIScene *)scene {
     // Called as the scene is being released by the system.

--- a/Places/SceneDelegate.m
+++ b/Places/SceneDelegate.m
@@ -18,13 +18,15 @@
 
 
 - (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    NSLog(@"Will connect to session called with session %@ and options %@", session, connectionOptions);
+    
     // If the user is already logged in, upon relaunching the app, don't need to login again
     if (PFUser.currentUser) {
         UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     
         self.window.rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"TabBarController"];
     }
-    // TODO: may need to handle custom URL here for when the app isn't launched and the user clicks a custom URL
+    // may need to handle custom URL here for when the app isn't launched and the user clicks a custom URL
 }
 
 
@@ -36,8 +38,6 @@
     NSLog(@"url path: %@", [url path]);
     NSString *itineraryObjectID = [[url path] substringFromIndex:1]; // remove "/" from path
     NSLog(@"itineraryObjectID: %@", itineraryObjectID);
-    // try to open up itinerary view, and from there, could perform segue to the specific detail view??
-//    [self.window.rootViewController performSegueWithIdentifier:@"" sender:nil];
 
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
     ItineraryDetailViewController *itineraryDetailViewController =[storyboard instantiateViewControllerWithIdentifier:@"ItineraryDetailView"];

--- a/Places/SceneDelegate.m
+++ b/Places/SceneDelegate.m
@@ -7,6 +7,7 @@
 
 #import "SceneDelegate.h"
 #import "AppDelegate.h"
+#import "ItineraryDetailViewController.h"
 @import Parse;
 
 @interface SceneDelegate ()
@@ -23,11 +24,36 @@
     
         self.window.rootViewController = [storyboard instantiateViewControllerWithIdentifier:@"TabBarController"];
     }
-    
+    // TODO: may need to handle custom URL here for when the app isn't launched and the user clicks a custom URL
 }
 
-- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
-    NSLog(@"Continuing to handle user activity");
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+    NSLog(@"This should be called if app opens a URL while running or suspended in memory");
+    NSURL *url = [[URLContexts allObjects] firstObject].URL;
+    NSLog(@"url recieved: %@", url.absoluteString);
+    NSLog(@"host: %@", [url host]);
+    NSLog(@"url path: %@", [url path]);
+    NSString *itineraryObjectID = [[url path] substringFromIndex:1]; // remove "/" from path
+    NSLog(@"itineraryObjectID: %@", itineraryObjectID);
+    // try to open up itinerary view, and from there, could perform segue to the specific detail view??
+//    [self.window.rootViewController performSegueWithIdentifier:@"" sender:nil];
+
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    ItineraryDetailViewController *itineraryDetailViewController =[storyboard instantiateViewControllerWithIdentifier:@"ItineraryDetailView"];
+    NSLog(@"Have an itinerary Detail View Controller %@", itineraryDetailViewController);
+    
+    PFQuery *query = [PFQuery queryWithClassName:@"Itinerary"];
+    [query getObjectInBackgroundWithId:itineraryObjectID block:^(PFObject *itinerary, NSError *error) {
+        if (!error) {
+            itineraryDetailViewController.itinerary = itinerary;
+            NSLog(@"Got the itinerary to set the detail view with itinerary %@", itineraryDetailViewController.itinerary);
+            
+            UITabBarController *tabBarController = self.window.rootViewController;
+            [tabBarController setSelectedIndex:2];
+            [[tabBarController selectedViewController] pushViewController:itineraryDetailViewController animated:true];
+        }
+    }];
 }
 
 - (void)sceneDidDisconnect:(UIScene *)scene {

--- a/Places/View Controllers/ItinerariesTableViewController.m
+++ b/Places/View Controllers/ItinerariesTableViewController.m
@@ -97,8 +97,8 @@
         ComposeItineraryViewController *composeItineraryViewController = (ComposeItineraryViewController *)navigationController.topViewController;
         composeItineraryViewController.delegate = self;
     } else if ([segue.identifier isEqualToString:@"ItineraryDetailViewSegue"]) {
-        ItineraryDetailViewController *itineraryDetailViewController = [segue destinationViewController];
         ItineraryTableViewCell *tappedItinerary = sender;
+        ItineraryDetailViewController *itineraryDetailViewController = [segue destinationViewController];
         itineraryDetailViewController.itinerary = tappedItinerary.itinerary;
     }
 }

--- a/Places/View Controllers/ItineraryDetailViewController.m
+++ b/Places/View Controllers/ItineraryDetailViewController.m
@@ -67,7 +67,8 @@
 
 -(void)sendMessage {
     //create a message
-    NSString *theMessage = [NSString stringWithFormat:@"Checkout my itinerary %@ that I created in the Places app!", self.itinerary.name];
+    NSURL *itineraryURL = [NSURL URLWithString:[NSString stringWithFormat:@"places://itinerary/%@", self.itinerary.objectId]];
+    NSString *theMessage = [NSString stringWithFormat:@"Checkout my itinerary %@ that I created in the Places app! %@", self.itinerary.name, itineraryURL];
     NSArray *items = @[theMessage];
 
     // build an activity view controller

--- a/Places/View Controllers/ItineraryDetailViewController.m
+++ b/Places/View Controllers/ItineraryDetailViewController.m
@@ -24,6 +24,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
     self.itinerary.fetchIfNeeded;
     
     self.itineraryNameLabel.text = self.itinerary[@"name"];


### PR DESCRIPTION
With this PR, the user should be able to click on a custom URL which prompts the app to open. 
- Clicking on the link prompts the app to open with the correct itinerary’s detail view, alongside the tab bar and navigation button to go back to the itinerary table view.

Test plan:
- In User 1's account, share an itinerary via message
- Log out of User 1 and log into User 2
- Click on the itinerary link in message
- See that the the correct itinerary's detail view opens, with tab bar and navigation button back to itinerary table view
